### PR TITLE
Port Upstream 5.0.1

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.spec.jakarta.el</groupId>
         <artifactId>jboss-el-api_5.0_spec-parent</artifactId>
-        <version>4.0.0.Final-SNAPSHOT</version>
+        <version>4.0.0.CR2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/api/src/main/java/jakarta/el/BeanELResolver.java
+++ b/api/src/main/java/jakarta/el/BeanELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -143,7 +143,7 @@ public class BeanELResolver extends ELResolver {
         BeanProperty beanProperty = getBeanProperty(context, base, property);
         context.setPropertyResolved(true);
         
-        if (isReadOnly || beanProperty.isReadOnly()) {
+        if (isReadOnly || beanProperty.isReadOnly(base)) {
             return null;
         }
         
@@ -187,7 +187,7 @@ public class BeanELResolver extends ELResolver {
             return null;
         }
 
-        Method method = getBeanProperty(context, base, property).getReadMethod();
+        Method method = getBeanProperty(context, base, property).getReadMethod(base);
         if (method == null) {
             throw new PropertyNotFoundException(
                     getExceptionMessageString(context, "propertyNotReadable", new Object[] { base.getClass().getName(), property.toString() }));
@@ -255,7 +255,7 @@ public class BeanELResolver extends ELResolver {
             throw new PropertyNotWritableException(getExceptionMessageString(context, "resolverNotwritable", new Object[] { base.getClass().getName() }));
         }
 
-        Method method = getBeanProperty(context, base, property).getWriteMethod();
+        Method method = getBeanProperty(context, base, property).getWriteMethod(base);
         if (method == null) {
             throw new PropertyNotWritableException(
                     getExceptionMessageString(context, "propertyNotWritable", new Object[] { base.getClass().getName(), property.toString() }));
@@ -326,8 +326,9 @@ public class BeanELResolver extends ELResolver {
             return null;
         }
 
-        Method method = ELUtil.findMethod(base.getClass(), methodName.toString(), paramTypes, params, false);
-        method = BeanPropertiesCache.getMethod(base.getClass(), method);
+        Method method = ELUtil.findMethod(base.getClass(), base, methodName.toString(), paramTypes, params, false);
+        method = BeanPropertiesCache.getMethod(base.getClass(), base, method);
+
         for (Object param: params) {
             // If the parameters is a LambdaExpression, set the ELContext
             // for its evaluation
@@ -387,7 +388,7 @@ public class BeanELResolver extends ELResolver {
             return true;
         }
 
-        return getBeanProperty(context, base, property).isReadOnly();
+        return getBeanProperty(context, base, property).isReadOnly(base);
     }
 
     /**

--- a/api/src/main/java/jakarta/el/ELContext.java
+++ b/api/src/main/java/jakarta/el/ELContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -436,7 +436,8 @@ public abstract class ELContext {
         } finally {
             setPropertyResolved(propertyResolvedSave);
         }
-        return ELUtil.getExpressionFactory().coerceToType(obj, targetType);
+
+        return ELManager.getExpressionFactory().coerceToType(obj, targetType);
     }
 
 }

--- a/api/src/main/java/jakarta/el/ELUtil.java
+++ b/api/src/main/java/jakarta/el/ELUtil.java
@@ -23,8 +23,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,30 +48,11 @@ import org.jboss.el.cache.BeanPropertiesCache;
  * @author Dongbin Nie
  */
 class ELUtil {
-    private static final String EL_BC22_PROPERTY= "org.wildfly.el.bc2.2";
 
     /**
      * This class may not be constructed.
      */
     private ELUtil() {
-    }
-
-    static final java.util.Properties properties = new java.util.Properties();
-    private static ExpressionFactory exprFactory = null;
-    static {
-        setupProperties();
-    }
-
-    private static void setupProperties(){
-        boolean bc22Enabled = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-            public Boolean run() {
-                return Boolean.getBoolean(EL_BC22_PROPERTY);
-            }
-
-        });
-        if (bc22Enabled) {
-            properties.setProperty("jakarta.el.bc2.2", "true");
-        }
     }
 
     /**
@@ -180,13 +159,6 @@ class ELUtil {
         }
 
         return result;
-    }
-
-    static ExpressionFactory getExpressionFactory() {
-        if (exprFactory == null){
-            exprFactory = ExpressionFactory.newInstance(properties);
-        }
-        return exprFactory;
     }
 
     static Constructor<?> findConstructor(Class<?> klass, Class<?>[] paramTypes, Object[] params) {
@@ -557,7 +529,7 @@ class ELUtil {
         // TODO: This isn't pretty but it works. Significant refactoring would
         // be required to avoid the exception.
         try {
-            getExpressionFactory().coerceToType(src, target);
+            ELManager.getExpressionFactory().coerceToType(src, target);
         } catch (Exception e) {
             return false;
         }

--- a/api/src/main/java/jakarta/el/ELUtil.java
+++ b/api/src/main/java/jakarta/el/ELUtil.java
@@ -585,6 +585,7 @@ class ELUtil {
         return null;
     }
 
+    @SuppressWarnings("null") // params cannot be null when used
     static Object[] buildParameters(ELContext context, Class<?>[] parameterTypes, boolean isVarArgs, Object[] params) {
         Object[] parameters = null;
         if (parameterTypes.length > 0) {

--- a/api/src/main/java/jakarta/el/ELUtil.java
+++ b/api/src/main/java/jakarta/el/ELUtil.java
@@ -200,8 +200,8 @@ class ELUtil {
         }
     }
 
-    static Method findMethod(Class<?> klass, String methodName, Class<?>[] paramTypes, Object[] params, boolean staticOnly) {
-        Method method = findMethod(klass, methodName, paramTypes, params);
+    static Method findMethod(Class<?> klass, Object base, String methodName, Class<?>[] paramTypes, Object[] params, boolean staticOnly) {
+        Method method = findMethod(klass, base, methodName, paramTypes, params);
         if (staticOnly && !Modifier.isStatic(method.getModifiers())) {
             throw new MethodNotFoundException("Method " + methodName + "for class " + klass + " not found or accessible");
         }
@@ -223,7 +223,7 @@ class ELUtil {
         }
     }
 
-    static Method findMethod(Class<?> clazz, String methodName, Class<?>[] paramTypes, Object[] paramValues) {
+    static Method findMethod(Class<?> clazz, Object base, String methodName, Class<?>[] paramTypes, Object[] paramValues) {
         if (clazz == null || methodName == null) {
             throw new MethodNotFoundException("Method not found: " + clazz + "." + methodName + "(" + paramString(paramTypes) + ")");
         }
@@ -242,7 +242,7 @@ class ELUtil {
             return null;
         }
 
-        return getMethod(clazz, (Method) result.unWrap());
+        return getMethod(clazz, base, (Method) result.unWrap());
     }
 
     @SuppressWarnings("null")
@@ -559,10 +559,10 @@ class ELUtil {
      * for a non-public class that implements a public interface, the read/write methods will be for the class, and
      * therefore inaccessible. To correct this, a version of the same method must be found in a superclass or interface.
      */
-    static Method getMethod(Class<?> type, Method m) {
+    static Method getMethod(Class<?> type, Object base, Method m) {
         // BeanPropertiesCache.getMethod is implemented with the logic from this method in the Eclipse Jakarta EL API
         // We delegate to that here to avoid the need to duplicate that logic
-        return BeanPropertiesCache.getMethod(type, m);
+        return BeanPropertiesCache.getMethod(type, base, m);
     }
 
     static Constructor<?> getConstructor(Class<?> type, Constructor<?> c) {

--- a/api/src/main/java/jakarta/el/ELUtil.java
+++ b/api/src/main/java/jakarta/el/ELUtil.java
@@ -237,9 +237,6 @@ class ELUtil {
         return method;
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     static Object invokeMethod(ELContext context, Method method, Object base, Object[] params) {
 
         Object[] parameters = buildParameters(context, method.getParameterTypes(), method.isVarArgs(), params);
@@ -254,9 +251,6 @@ class ELUtil {
         }
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     static Method findMethod(Class<?> clazz, String methodName, Class<?>[] paramTypes, Object[] paramValues) {
         if (clazz == null || methodName == null) {
             throw new MethodNotFoundException("Method not found: " + clazz + "." + methodName + "(" + paramString(paramTypes) + ")");
@@ -279,9 +273,6 @@ class ELUtil {
         return getMethod(clazz, (Method) result.unWrap());
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     @SuppressWarnings("null")
     private static Wrapper findWrapper(Class<?> clazz, List<Wrapper> wrappers, String name, Class<?>[] paramTypes, Object[] paramValues) {
         List<Wrapper> assignableCandidates = new ArrayList<>();
@@ -379,12 +370,8 @@ class ELUtil {
         } else {
             throw new MethodNotFoundException("Method not found: " + clazz + "." + name + "(" + paramString(paramTypes) + ")");
         }
-
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static Wrapper findMostSpecificWrapper(List<Wrapper> candidates, Class<?>[] matchingTypes, boolean elSpecific, String errorMsg) {
         List<Wrapper> ambiguouses = new ArrayList<>();
         for (Wrapper candidate : candidates) {
@@ -412,9 +399,6 @@ class ELUtil {
         return ambiguouses.get(0);
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static int isMoreSpecific(Wrapper wrapper1, Wrapper wrapper2, Class<?>[] matchingTypes, boolean elSpecific) {
         Class<?>[] paramTypes1 = wrapper1.getParameterTypes();
         Class<?>[] paramTypes2 = wrapper2.getParameterTypes();
@@ -463,9 +447,6 @@ class ELUtil {
         return result;
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static int isMoreSpecific(Class<?> type1, Class<?> type2, Class<?> matchingType, boolean elSpecific) {
         type1 = getBoxingTypeIfPrimitive(type1);
         type2 = getBoxingTypeIfPrimitive(type2);
@@ -500,9 +481,6 @@ class ELUtil {
         }
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static Class<?> getBoxingTypeIfPrimitive(Class<?> clazz) {
         if (clazz.isPrimitive()) {
             if (clazz == Boolean.TYPE) {
@@ -533,9 +511,6 @@ class ELUtil {
         }
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static Class<?>[] getComparingParamTypesForVarArgsMethod(Class<?>[] paramTypes, int length) {
         Class<?>[] result = new Class<?>[length];
         System.arraycopy(paramTypes, 0, result, 0, paramTypes.length - 1);
@@ -547,9 +522,6 @@ class ELUtil {
         return result;
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static final String paramString(Class<?>[] types) {
         if (types != null) {
             StringBuilder sb = new StringBuilder();
@@ -568,9 +540,6 @@ class ELUtil {
         return null;
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     static boolean isAssignableFrom(Class<?> src, Class<?> target) {
         // src will always be an object
         // Short-cut. null is always assignable to an object and in Jakarta Expression Language null
@@ -584,9 +553,6 @@ class ELUtil {
         return target.isAssignableFrom(src);
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static boolean isCoercibleFrom(Object src, Class<?> target) {
         // TODO: This isn't pretty but it works. Significant refactoring would
         // be required to avoid the exception.
@@ -599,9 +565,6 @@ class ELUtil {
         return true;
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static Class<?>[] getTypesFromValues(Object[] values) {
         if (values == null) {
             return null;
@@ -620,12 +583,9 @@ class ELUtil {
     }
 
     /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     *
      * Get a public method form a public class or interface of a given method. Note that if a PropertyDescriptor is obtained
      * for a non-public class that implements a public interface, the read/write methods will be for the class, and
      * therefore inaccessible. To correct this, a version of the same method must be found in a superclass or interface.
-     *
      */
     static Method getMethod(Class<?> type, Method m) {
         // BeanPropertiesCache.getMethod is implemented with the logic from this method in the Eclipse Jakarta EL API
@@ -633,9 +593,6 @@ class ELUtil {
         return BeanPropertiesCache.getMethod(type, m);
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     static Constructor<?> getConstructor(Class<?> type, Constructor<?> c) {
         if (c == null || Modifier.isPublic(type.getModifiers())) {
             return c;
@@ -688,9 +645,6 @@ class ELUtil {
         return parameters;
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private abstract static class Wrapper {
 
         public static List<Wrapper> wrap(Class<?> clazz, Method[] methods, String name) {
@@ -722,9 +676,6 @@ class ELUtil {
         public abstract boolean isBridge();
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static class MethodWrapper extends Wrapper {
         private final Method m;
 
@@ -753,9 +704,6 @@ class ELUtil {
         }
     }
 
-    /*
-     * This method duplicates code in com.sun.el.util.ReflectionUtil. When making changes keep the code in sync.
-     */
     private static class ConstructorWrapper extends Wrapper {
         private final Constructor<?> c;
 
@@ -783,5 +731,4 @@ class ELUtil {
             return false;
         }
     }
-
 }

--- a/api/src/main/java/jakarta/el/ExpressionFactory.java
+++ b/api/src/main/java/jakarta/el/ExpressionFactory.java
@@ -105,7 +105,7 @@ public abstract class ExpressionFactory {
      * @return a new <code>ExpressionFactory</code> instance
      */
     public static ExpressionFactory newInstance() {
-        return ExpressionFactory.newInstance(ELUtil.properties);
+        return ExpressionFactory.newInstance(ELManager.properties);
     }
 
     /**

--- a/api/src/main/java/jakarta/el/StaticFieldELResolver.java
+++ b/api/src/main/java/jakarta/el/StaticFieldELResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates and others.
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -171,7 +171,7 @@ public class StaticFieldELResolver extends ELResolver {
             Constructor<?> constructor = ELUtil.findConstructor(klass, paramTypes, params);
             ret = ELUtil.invokeConstructor(context, constructor, params);
         } else {
-            Method method = ELUtil.findMethod(klass, name, paramTypes, params, true);
+            Method method = ELUtil.findMethod(klass, base, name, paramTypes, params, true);
             ret = ELUtil.invokeMethod(context, method, null, params);
         }
         context.setPropertyResolved(base, methodName);

--- a/api/src/test/java/jakarta/el/TestELUtil.java
+++ b/api/src/test/java/jakarta/el/TestELUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package jakarta.el;
+
+import java.lang.reflect.Method;
+import java.util.TimeZone;
+
+import org.junit.Test;
+
+public class TestELUtil {
+
+    /*
+     * https://github.com/jakartaee/expression-language/issues/188
+     */
+    @Test
+    public void testAccessibleMethod() throws Exception {
+        TimeZone tz = TimeZone.getDefault();
+        Method m = ELUtil.findMethod(tz.getClass(), tz, "getRawOffset", null, null);
+        m.invoke(tz);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <groupId>org.jboss.spec.jakarta.el</groupId>
     <artifactId>jboss-el-api_5.0_spec-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.0.Final-SNAPSHOT</version>
+    <version>4.0.0.CR2-SNAPSHOT</version>
 
     <name>Jakarta Expression Language</name>
     <description>Jakarta Expression Language</description>


### PR DESCRIPTION
Port upstream changes between 5.0.0 and 5.0.1

https://github.com/jakartaee/expression-language/compare/5.0.0-RELEASE-api...5.0.1-RELEASE-api

Note that these aren't all simple cherry-picks as our use of BeanPropertiesCache means some of the changed code is there instead of in BeanELResolver.