### PR TITLE
[JBEE-258] FactoryFinderCache does not properly handle comments in service

### DIFF
--- a/api/src/main/java/org/jboss/el/cache/FactoryFinderCache.java
+++ b/api/src/main/java/org/jboss/el/cache/FactoryFinderCache.java
@@ -22,11 +22,12 @@
 
 package org.jboss.el.cache;
 
-import java.lang.Class;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.ServiceLoader;
 
 /**
  * @author Stuart Douglas
@@ -81,21 +82,34 @@ public class FactoryFinderCache {
             }
         }
 
-        Object result = null;
+        String serviceId = "META-INF/services/" + factoryId;
         // try to find services in CLASSPATH
         try {
-            Class factoryClass = Class.forName(factoryId);
-            ServiceLoader<Object> serviceLoader = ServiceLoader.load(factoryClass, classLoader);
-            Iterator<Object> iter = serviceLoader.iterator();
-            while (result == null && iter.hasNext()) {
-                result = iter.next();
+            InputStream is = null;
+            if (classLoader == null) {
+                is = ClassLoader.getSystemResourceAsStream(serviceId);
+            } else {
+                is = classLoader.getResourceAsStream(serviceId);
             }
 
-            if (result != null) {
-                if (classCache != null) {
-                    classCache.put(new CacheKey(classLoader, factoryId), result.getClass().getName());
+            if (is != null) {
+                BufferedReader rd =
+                        new BufferedReader(new InputStreamReader(is, "UTF-8"));
+
+                String factoryClassName;
+                do {
+                    factoryClassName = sanitize(rd.readLine());
+                } while (factoryClassName != null && factoryClassName.isEmpty());
+
+                rd.close();
+
+                if (factoryClassName != null &&
+                        !"".equals(factoryClassName)) {
+                    if (classCache != null) {
+                        classCache.put(new CacheKey(classLoader, factoryId), factoryClassName);
+                    }
+                    return factoryClassName;
                 }
-                return result.getClass().getName();
             }
         } catch (Exception ex) {
         }
@@ -103,6 +117,28 @@ public class FactoryFinderCache {
             classCache.put(new CacheKey(classLoader, factoryId), "");
         }
         return null;
+    }
+
+    static String sanitize(String line) {
+        if (line == null) {
+            return null;
+        }
+
+        // strip comment
+        int idx = line.indexOf('#');
+        if (idx >= 0) {
+            line = line.substring(0, idx);
+        }
+
+        // strip spaces and tabs
+        while (line.startsWith(" ") || line.startsWith("\t")) {
+            line = line.substring(1);
+        }
+        while (line.endsWith(" ") || line.endsWith("\t")) {
+            line = line.substring(0, line.length() - 1);
+        }
+
+        return line;
     }
 
     private static class CacheKey {

--- a/api/src/main/java/org/jboss/el/cache/FactoryFinderCache.java
+++ b/api/src/main/java/org/jboss/el/cache/FactoryFinderCache.java
@@ -22,9 +22,6 @@
 
 package org.jboss.el.cache;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.lang.Class;
 import java.util.Iterator;
 import java.util.Map;

--- a/api/src/test/java/org/jboss/el/cache/FactoryFinderCacheTestCase.java
+++ b/api/src/test/java/org/jboss/el/cache/FactoryFinderCacheTestCase.java
@@ -7,8 +7,33 @@ public class FactoryFinderCacheTestCase {
 
     @Test
     public void testServiceFileWithComment() {
+        String className = FactoryFinderCache.loadImplementationClassName("org.jboss.el.cache.TestService-comment",
+                this.getClass().getClassLoader());
+        Assert.assertEquals("org.jboss.el.cache.TestServiceImpl", className);
+    }
+
+    @Test
+    public void testEmptyServiceFile() {
+        String className = FactoryFinderCache.loadImplementationClassName("org.jboss.el.cache.TestService-empty",
+                this.getClass().getClassLoader());
+        Assert.assertNull(className);
+    }
+
+    @Test
+    public void testServiceFile() {
         String className = FactoryFinderCache.loadImplementationClassName("org.jboss.el.cache.TestService",
                 this.getClass().getClassLoader());
         Assert.assertEquals("org.jboss.el.cache.TestServiceImpl", className);
+    }
+
+    @Test
+    public void testSanitizeMethod() {
+        Assert.assertEquals("ClassName", FactoryFinderCache.sanitize("ClassName"));
+        Assert.assertEquals("ClassName", FactoryFinderCache.sanitize(" ClassName "));
+        Assert.assertEquals("ClassName", FactoryFinderCache.sanitize("\tClassName\t"));
+        Assert.assertEquals("ClassName", FactoryFinderCache.sanitize(" \tClassName\t # comment..."));
+        Assert.assertEquals("", FactoryFinderCache.sanitize("# only comment..."));
+        Assert.assertEquals("", FactoryFinderCache.sanitize(""));
+        Assert.assertNull(FactoryFinderCache.sanitize(null));
     }
 }

--- a/api/src/test/java/org/jboss/el/cache/FactoryFinderCacheTestCase.java
+++ b/api/src/test/java/org/jboss/el/cache/FactoryFinderCacheTestCase.java
@@ -1,0 +1,14 @@
+package org.jboss.el.cache;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FactoryFinderCacheTestCase {
+
+    @Test
+    public void testServiceFileWithComment() {
+        String className = FactoryFinderCache.loadImplementationClassName("org.jboss.el.cache.TestService",
+                this.getClass().getClassLoader());
+        Assert.assertEquals("org.jboss.el.cache.TestServiceImpl", className);
+    }
+}

--- a/api/src/test/java/org/jboss/el/cache/TestService.java
+++ b/api/src/test/java/org/jboss/el/cache/TestService.java
@@ -1,0 +1,5 @@
+package org.jboss.el.cache;
+
+public interface TestService {
+    void execute();
+}

--- a/api/src/test/java/org/jboss/el/cache/TestServiceImpl.java
+++ b/api/src/test/java/org/jboss/el/cache/TestServiceImpl.java
@@ -1,0 +1,9 @@
+package org.jboss.el.cache;
+
+public class TestServiceImpl implements TestService {
+
+    @Override
+    public void execute() {
+        // pass
+    }
+}

--- a/api/src/test/resources/META-INF/services/org.jboss.el.cache.TestService
+++ b/api/src/test/resources/META-INF/services/org.jboss.el.cache.TestService
@@ -1,0 +1,2 @@
+# Comment
+org.jboss.el.cache.TestServiceImpl

--- a/api/src/test/resources/META-INF/services/org.jboss.el.cache.TestService-comment
+++ b/api/src/test/resources/META-INF/services/org.jboss.el.cache.TestService-comment
@@ -1,1 +1,2 @@
+# Comment
 org.jboss.el.cache.TestServiceImpl


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEE-258
Upstream PR: https://github.com/jboss/jboss-jakarta-el-api_spec/pull/12

Alternative impl that keeps using class.getResourceAsStream(META-INF/services/xxxx).