### PR TITLE
Deprecate application use of org.jboss.el.cache.BeanPropertiesCache + org.jboss.el.cache.FactoryFinderCache

### DIFF
--- a/api/src/main/java/org/jboss/el/cache/BeanPropertiesCache.java
+++ b/api/src/main/java/org/jboss/el/cache/BeanPropertiesCache.java
@@ -39,7 +39,9 @@ import jakarta.el.ELException;
 
 /**
  * @author Stuart Douglas
+ * @deprecated for removal in a future major release.
  */
+@Deprecated
 public class BeanPropertiesCache {
 
     static private class BPSoftReference extends SoftReference<BeanProperties> {

--- a/api/src/main/java/org/jboss/el/cache/FactoryFinderCache.java
+++ b/api/src/main/java/org/jboss/el/cache/FactoryFinderCache.java
@@ -31,7 +31,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Stuart Douglas
+ * @deprecated for removal in a future major release.
  */
+@Deprecated
 public class FactoryFinderCache {
 
     private static final Map<CacheKey, String> CLASS_CACHE = new ConcurrentHashMap<CacheKey, String>();


### PR DESCRIPTION
Deprecate BeanPropertiesCache + FactoryFinderCache for removal