### PR TITLE
JBEE-262: Deprecate use of org.jboss.el.cache.BeanPropertiesCache + org.jboss.el.cache.FactoryFinderCache

### DIFF
--- a/api/src/main/java/org/jboss/el/cache/BeanPropertiesCache.java
+++ b/api/src/main/java/org/jboss/el/cache/BeanPropertiesCache.java
@@ -14,7 +14,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Stuart Douglas
+ * @deprecated for removal in a future major release.
  */
+@Deprecated
 public class BeanPropertiesCache {
 
     static private class BPSoftReference extends SoftReference<Object> {

--- a/api/src/main/java/org/jboss/el/cache/FactoryFinderCache.java
+++ b/api/src/main/java/org/jboss/el/cache/FactoryFinderCache.java
@@ -13,7 +13,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Stuart Douglas
+ * @deprecated for removal in a future major release.
  */
+@Deprecated
 public class FactoryFinderCache {
 
     private static final Map<CacheKey, String> CLASS_CACHE = new ConcurrentHashMap<CacheKey, String>();


### PR DESCRIPTION
Deprecate BeanPropertiesCache + FactoryFinderCache for removal

This brings in the same change as https://github.com/wildfly/jboss-jakarta-el-api_spec/pull/16