### PR TITLE
Update CONTRIBUTING content in the master branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,48 +1,54 @@
-# Contributing to Jakarta Expression Language
+# Contributing to the WildFly Jakarta Expression Language API project
 
 Thanks for your interest in this project.
 
-## Project description
+## Overview
 
-Jakarta Expression Language provides an important mechanism
-for enabling the presentation layer (web pages) to communicate with the
-application logic (managed beans). Jakarta Expression Language is used by several Jakarta EE
-technologies, such as Jakarta Faces, Jakarta Server Pages, Jakarta Security and Contexts and
-Dependency Injection for Jakarta EE (CDI). 
+This is a WildFly-specific fork of the Eclipse EE4J Jakarta Expression Language [spec and API repository](https://github.com/jakartaee/expression-language).
 
-Jakarta Expression Language can also be used in stand-alone environments.
+The purpose of this project is to maintain a variant of the Jakarta Expression Language API binary that is tailored for use in a WildFly application server environment.
 
-* https://projects.eclipse.org/projects/ee4j.el
+A key goal of this project is to minimize the differences between the API binaries produced by the project and those from Eclipse EE4J. Generally this means limiting changes to things specific to operation in a WildFly server. _Developers interested in making more broadly applicable changes are encouraged to contribute to [the Eclipse EE4J repository](https://github.com/jakartaee/expression-language) instead_.
+
+We expect all contributors and users to follow our [Code of Conduct](https://github.com/wildfly/jboss-jakarta-el-api_spec#coc-ov-file) when communicating through project channels. These include, but are not limited to: chat, issues, code.
+
+## Legal
+
+All original contributions to this project are licensed under the
+[Eclipse Public License - v 2.0](https://www.eclipse.org/legal/epl-v20.html),
+or, if another license is specified as governing the file or directory being modified, such other license.
+The EPL 2.0 license text is included verbatim in the [`LICENSE.md`](LICENSE.md) file.
+
+All contributions are subject to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+The DCO text is available verbatim in the [dco.txt](dco.txt) file in the root directory of the repository.
+
+### Compliance with Laws and Regulations
+
+All contributions must comply with applicable laws and regulations, including U.S. export control and sanctions restrictions.
+For background, see the Linux Foundation’s guidance:
+[Navigating Global Regulations and Open Source: US OFAC Sanctions](https://www.linuxfoundation.org/blog/navigating-global-regulations-and-open-source-us-ofac-sanctions).
+
+## Issues
+
+This project uses GitHub issues to manage issues. Issues can be found [here](https://github.com/wildfly/jboss-jakarta-el-api_spec/issues).
+
+Historical issues can also be found in the [JBEE project in Red Hat JIRA](https://issues.redhat.com/projects/JBEE/summary), often associated with the [jboss-el-api JIRA component](https://issues.redhat.com/issues/?jql=project%20%3D%20JBEE%20AND%20component%20%3D%20jboss-el-api).
+
+## Branches
+
+The project maintains a branch per major/minor version of the Jakarta Expression Language specification for which WildFly needed an API jar.
+
+Changes made to the branch for an earlier version of the spec must also be made to the branches for later versions, if the change is relevant.
+
+The `master` branch is unmaintained, will likely be removed and can be ignored.
 
 ## Developer resources
 
-Information regarding source code management, builds, coding standards, and
-more.
-
-* https://projects.eclipse.org/projects/ee4j.el/developer
-
-The project maintains the following source code repositories
-
-* https://github.com/eclipse-ee4j/el-ri
-
-## Eclipse Contributor Agreement
-
-Before your contribution can be accepted by the project team contributors must
-electronically sign the Eclipse Contributor Agreement (ECA).
-
-* http://www.eclipse.org/legal/ECA.php
-
-Commits that are provided by non-committers must have a Signed-off-by field in
-the footer indicating that the author is aware of the terms by which the
-contribution has been provided to the project. The non-committer must
-additionally have an Eclipse Foundation account and must have a signed Eclipse
-Contributor Agreement (ECA) on file.
-
-For more information, please see the Eclipse Committer Handbook:
-https://www.eclipse.org/projects/handbook/#resources-commit
+The [Hacking on WildFly](https://docs.wildfly.org/38/Hacking_On_WildFly.html) document contains broadly useful information about contributing to projects in the WildFly family. (Note that it does contain a lot of information specific to the main WildFly server project and to WildFly Core.)
 
 ## Contact
 
-Contact the project developers via the project's "dev" list.
+The project developers can be reached in two ways:
 
-* 
+* Via the mailing list - https://lists.jboss.org/mailman/listinfo/wildfly-dev
+* On Zulip (recommended) - https://wildfly.zulipchat.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Jakarta Expression Language
+# WildFly Jakarta Expression Language API
 
-This is a fork of the Jakarta Expression Language repository.
+This is a WildFly-specific fork of the Eclipse EE4J Jakarta Expression Language [spec and API repository](https://github.com/jakartaee/expression-language).
+
+The purpose of this project is to maintain a variant of the Jakarta Expression Language API binary that is tailored for use in a WildFly application server environment.
+
+This fork is limited to the API portion of the Eclipse EE4J repository. Specification and TCK content in the Eclipse EE4J repository has been removed.
 
 [Online JavaDoc](https://javadoc.io/doc/jakarta.el/jakarta.el-api/)
 

--- a/dco.txt
+++ b/dco.txt
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
This is the same as what I did for 4.0.x and jakarta-6.0.x, but for master.

This is just for satisfying the Commonhaus policy compliance scanner, which I believe checks a repo's 'master' or 'main' branch.